### PR TITLE
Add catboost for arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # noarch: python
   skip: True  # [py>=310]
-  number: 5
+  number: 6
   script: {{ PYTHON }} -m pip install ./tabular -vv
   script_env:
    - RELEASE=1
@@ -36,7 +36,7 @@ requirements:
     - pytorch <1.13,>=1.9  # [not win]
     - lightgbm
     - xgboost
-    - catboost  # [not arm64]
+    - catboost  
     # - fastai  # not available on conda-forge yet
     - autogluon.core =={{ version }}
     - autogluon.features =={{ version }}


### PR DESCRIPTION
Catboost now supports arm64. This PR removes `# [not arm64]` from catboost. 

https://github.com/conda-forge/catboost-feedstock/pull/95

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
