### PR TITLE
Add fastai dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - lightgbm
     - xgboost
     - catboost  
-    - fastai  
+    - fastai  # [not win]   
     - autogluon.core =={{ version }}
     - autogluon.features =={{ version }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # noarch: python
   skip: True  # [py>=310]
-  number: 6
+  number: 7
   script: {{ PYTHON }} -m pip install ./tabular -vv
   script_env:
    - RELEASE=1
@@ -37,7 +37,7 @@ requirements:
     - lightgbm
     - xgboost
     - catboost  
-    # - fastai  # not available on conda-forge yet
+    - fastai  
     - autogluon.core =={{ version }}
     - autogluon.features =={{ version }}
 


### PR DESCRIPTION
[fastai](https://anaconda.org/conda-forge/fastai) is now available conda-forge. This PR adds the fastai to the dependency list of `autogluon.tabular`. 

@Innixma  @gradientsky

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
