### PR TITLE
drop fastai for py312 due to no support in conda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 4 
+  number: 5 
   script: {{ PYTHON }} -m pip install ./tabular -vv
   script_env:
     - RELEASE=1
@@ -42,7 +42,7 @@ requirements:
     - catboost >=1.1,<1.2  # [osx and py<311]
     - catboost >=1.1,<1.3  # [not osx]
     - xgboost >=1.6,<2.2
-    - fastai >=2.3.1,<2.8
+    - fastai >=2.3.1,<2.8  # [py<312]
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
